### PR TITLE
Source-Links not properly escaped

### DIFF
--- a/ExceptionHandler.php
+++ b/ExceptionHandler.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Debug\Exception\OutOfMemoryException;
 
-/**
+/**F
  * ExceptionHandler converts an exception to a Response object.
  *
  * It is mostly useful in debug mode to replace the default PHP/XDebug
@@ -399,7 +399,7 @@ EOF;
         if ($linkFormat = $this->fileLinkFormat) {
             $link = str_replace(array('%f', '%l'), array($path, $line), $linkFormat);
 
-            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', $link, $file, $line);
+            return sprintf(' in <a href="%s" title="Go to source">%s line %d</a>', htmlspecialchars($link), $file, $line);
         }
 
         return sprintf(' in <a title="%s line %3$d" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">%s line %d</a>', $path, $file, $line);


### PR DESCRIPTION
Example (PHPstorm Remote Call)

```
xdebug.file_link_format="javascript:var rq = new XMLHttpRequest(); rq.open(\"GET\", \"http://localhost:8091?message=%f:%l\", true); rq.send(null);"
```

causes errors (does not work). With this patch this is fixed
