### PR TITLE
TraceAsString for debugging problems in PhpStorm->Tools->Analyze StackTrace

### DIFF
--- a/ErrorHandler.php
+++ b/ErrorHandler.php
@@ -465,7 +465,7 @@ class ErrorHandler
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
                 'level' => error_reporting(),
-                'stack' => $exception->getTrace(),
+                'stack' => $exception->getTraceAsString(),
             );
             if ($exception instanceof FatalErrorException) {
                 if ($exception instanceof FatalThrowableError) {


### PR DESCRIPTION
I want to see TraceAsString for debugging problems in PhpStorm->Tools->Analyze StackTrace

Now in my logs I see:

```
{
    "message": "Fatal Parse Error: syntax error, unexpected 'sadf' (T_STRING)",
    "context": {
        "type": 4,
        "file": "\/var\/www\/src\/Acme\/SecurityBundle\/Controller\/DefaultController.php",
        "line": 511,
        "level": 22527,
        "stack": [
            {
                "function": "Composer\\Autoload\\includeFile",
                "file": "\/var\/www\/vendor\/composer\/ClassLoader.php",
                "line": 301,
                "args": {
                    "file": "???"
                }
            },
            {
                "function": "loadClass",
                "type": "->",
                "class": "Composer\\Autoload\\ClassLoader",
                "file": "\/var\/www\/vendor\/symfony\/symfony\/src\/Symfony\/Component\/Routing\/Loader\/AnnotationClassLoader.php",
                "line": 107,
                "args": {
                    "class": "???"
                }
            },
            //...
        ]
    }
}
```

But PhpStorm->Tools->Analyze StackTrace use next format:

```
{
    "message": "Fatal Parse Error: syntax error, unexpected 'sadf' (T_STRING)",
    "context": {
        "type": 4,
        "file": "\/var\/www\/src\/Acme\/SecurityBundle\/Controller\/DefaultController.php",
        "line": 511,
        "level": 22527,
        "stack": "#0 [internal function]: Debug\\Monolog\\Processor\\Debug->__invoke(Array)
#1 /var/www/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(60): call_user_func(Object(Debug\\Monolog\\Processor\\Debug), Array)
#2 /var/www/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(33): Monolog\\Handler\\AbstractProcessingHandler->processRecord(Array)
#3 /var/www/vendor/monolog/monolog/src/Monolog/Logger.php(289): Monolog\\Handler\\AbstractProcessingHandler->handle(Array)
#4 /var/www/vendor/monolog/monolog/src/Monolog/Logger.php(467): Monolog\\Logger->addRecord(500, 'Fatal Parse Err...', Array)
#5 /var/www/vendor/symfony/symfony/src/Symfony/Component/Debug/ErrorHandler.php(490): Monolog\\Logger->log('critical', 'Fatal Parse Err...', Array)
#6 /var/www/vendor/symfony/symfony/src/Symfony/Component/Debug/ErrorHandler.php(565): Symfony\\Component\\Debug\\ErrorHandler->handleException(Object(Symfony\\Component\\Debug\\Exception\\FatalErrorException), Array)
#7 [internal function]: Symfony\\Component\\Debug\\ErrorHandler::handleFatalError()
#8 {main}"
    }
}
```
